### PR TITLE
Test parsing actions tbprofiler version for proper provenance output

### DIFF
--- a/modules/tbprofiler.nf
+++ b/modules/tbprofiler.nf
@@ -92,7 +92,7 @@ process tbprofiler {
     printf -- "- process_name: tbprofiler\\n"                  >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "  tools:\\n"                                    >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "    - tool_name: tb-profiler\\n"                >> ${sample_id}_tbprofiler_provenance.yml
-    printf -- "      tool_version: \$(tb-profiler profile --version 2>&1 | tail -n1)\\n" >> ${sample_id}_tbprofiler_provenance.yml
+    printf -- "      tool_version: \$(tb-profiler profile --version )\\n" >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      subcommand: profile\\n"                   >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      parameters:\\n"                           >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "        - parameter: --platform\\n"             >> ${sample_id}_tbprofiler_provenance.yml

--- a/modules/tbprofiler.nf
+++ b/modules/tbprofiler.nf
@@ -92,7 +92,7 @@ process tbprofiler {
     printf -- "- process_name: tbprofiler\\n"                  >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "  tools:\\n"                                    >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "    - tool_name: tb-profiler\\n"                >> ${sample_id}_tbprofiler_provenance.yml
-    printf -- "      tool_version: \$(tb-profiler profile --version 2>&1 | tail -n1)\n"\\n" >> ${sample_id}_tbprofiler_provenance.yml
+    printf -- "      tool_version: \$(tb-profiler profile --version 2>&1 | tail -n1)\\n" >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      subcommand: profile\\n"                   >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      parameters:\\n"                           >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "        - parameter: --platform\\n"             >> ${sample_id}_tbprofiler_provenance.yml

--- a/modules/tbprofiler.nf
+++ b/modules/tbprofiler.nf
@@ -92,7 +92,7 @@ process tbprofiler {
     printf -- "- process_name: tbprofiler\\n"                  >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "  tools:\\n"                                    >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "    - tool_name: tb-profiler\\n"                >> ${sample_id}_tbprofiler_provenance.yml
-    printf -- "      tool_version: \$(tb-profiler profile --version )\\n" >> ${sample_id}_tbprofiler_provenance.yml
+    printf -- "      tool_version: \$(tb-profiler profile --version | cut -d ' ' -f 3)\\n" >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      subcommand: profile\\n"                   >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      parameters:\\n"                           >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "        - parameter: --platform\\n"             >> ${sample_id}_tbprofiler_provenance.yml

--- a/modules/tbprofiler.nf
+++ b/modules/tbprofiler.nf
@@ -92,7 +92,7 @@ process tbprofiler {
     printf -- "- process_name: tbprofiler\\n"                  >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "  tools:\\n"                                    >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "    - tool_name: tb-profiler\\n"                >> ${sample_id}_tbprofiler_provenance.yml
-    printf -- "      tool_version: \$(tb-profiler profile --version 2>&1 | cut -d ' ' -f 3)\\n" >> ${sample_id}_tbprofiler_provenance.yml
+    printf -- "      tool_version: \$(tb-profiler profile --version 2>&1 | tail -n1)\n"\\n" >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      subcommand: profile\\n"                   >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "      parameters:\\n"                           >> ${sample_id}_tbprofiler_provenance.yml
     printf -- "        - parameter: --platform\\n"             >> ${sample_id}_tbprofiler_provenance.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,7 @@ def parsePipelineName(name) {
 profiles {
     conda {
 	conda.enabled = true
-	conda.useMamba = true
+	//conda.useMamba = true
 	process.conda = "$baseDir/environments/environment.yml"
 	if (params.cache){
 	    conda.cacheDir = params.cache

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,6 @@ def parsePipelineName(name) {
 profiles {
     conda {
 	conda.enabled = true
-	//conda.useMamba = true
 	process.conda = "$baseDir/environments/environment.yml"
 	if (params.cache){
 	    conda.cacheDir = params.cache


### PR DESCRIPTION
Fixes #48 

The way the tbprofiler version was being accessed for the provenance output was causing issues when printing stderr to stdout with the `&2>$1` in the github actions testing environment. [Removing this resolved the error](https://github.com/BCCDC-PHL/tbprofiler-nf/pull/59/files#diff-e29d893f4aeb5db41149d4646de187894efd840be1545221639d67cfe9ff8568L95)

After this, Nextflow version 24.10.6 was still failing when using mamba for installation, so[ removing mamba](https://github.com/BCCDC-PHL/tbprofiler-nf/pull/59/files#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL57) fully resolved actions testing issues.